### PR TITLE
KUZBO-71 Notify the user on (dis)connection with Kuzzle server

### DIFF
--- a/features/appWide.feature
+++ b/features/appWide.feature
@@ -1,0 +1,6 @@
+Feature: Test application-wide features
+
+  @currentTest
+  Scenario: Display a notification while disconnected from the Kuzzle server
+    When I shut down the Kuzzle server
+    Then I get a disconnection notification

--- a/features/step_definitions/appWide.js
+++ b/features/step_definitions/appWide.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+
+module.exports = function () {
+  this.Given(/^I shut down the Kuzzle server$/, function (callback) {
+    browser
+      // WARNING - this step is incomplete since this method is not
+      // supported by GhostDriver. We still need to find a way to
+      // shut down / start Kuzzle via Cucumber JS.
+
+      // .setNetworkConnection({type: 1})
+      .call(callback);
+  });
+
+  this.Then(/^I get a disconnection notification$/, function (callback) {
+    browser
+      pause(1000)
+      .waitForVisible('.ui-notification h3')
+      .getText('.ui-notification h3')
+      .then(text => {
+        assert.equal(text, 'Houston, we have a problem.');
+      })
+      .call(callback);
+    });
+};

--- a/public/javascripts/common/mainApp.controller.js
+++ b/public/javascripts/common/mainApp.controller.js
@@ -5,9 +5,40 @@ angular.module('kuzzle')
   'AuthService',
   'Session',
   'AUTH_EVENTS',
-  function ($rootScope, $scope, Auth, Session, AUTH_EVENTS) {
+  'Notification',
+  'kuzzleSdk',
+  function ($rootScope, $scope, Auth, Session, AUTH_EVENTS, Notification, kuzzle) {
+  var currentNotification = null;
+
+  var onConnected = function () {
+    Notification.clearAll();
+    currentNotification = Notification.success({
+      title: 'Yay! Back into bizness!',
+      message: 'Successfully reconnected to the Kuzzle server.',
+      delay: 3500
+    });
+  }
+
+  var onDisconnected = function () {
+    var reconnectMsg = (kuzzle.autoReconnect) ?
+      'We\'ll automatically reconnect once the Kuzzle server is up again.' :
+      'You\'ll have to reload the page when the Kuzzle server is up again.';
+
+    var notificationCfg = {
+      title: 'Houston, we have a problem.',
+      message: 'The connection with the Kuzzle server is lost. ' + reconnectMsg,
+      delay: null
+    };
+
+    currentNotification = (kuzzle.autoReconnect) ?
+      Notification.warning(notificationCfg) :
+      Notification.error(notificationCfg);
+  }
+
   $scope.init = function () {
     Session.resumeFromCookie();
+    kuzzle.addListener('reconnected', onConnected);
+    kuzzle.addListener('disconnected', onDisconnected);
   };
 
   $scope.session = Session.session;

--- a/public/javascripts/common/mainApp.controller.js
+++ b/public/javascripts/common/mainApp.controller.js
@@ -17,7 +17,7 @@ angular.module('kuzzle')
       message: 'Successfully reconnected to the Kuzzle server.',
       delay: 3500
     });
-  }
+  };
 
   var onDisconnected = function () {
     var reconnectMsg = (kuzzle.autoReconnect) ?
@@ -33,7 +33,7 @@ angular.module('kuzzle')
     currentNotification = (kuzzle.autoReconnect) ?
       Notification.warning(notificationCfg) :
       Notification.error(notificationCfg);
-  }
+  };
 
   $scope.init = function () {
     Session.resumeFromCookie();


### PR DESCRIPTION
I've added some notifications on connection / disconnection events triggered by the Kuzzle SDK.
Your feedback is encouraged on the following points

* When the kuzzle SDK is initialized with the `autoReconnect: true`, the notification is a warning (something between yellow and orange), while if it's set to `false`, the notification is an error (red). I've done so because I estimate that if you are in the middle of a form, your work will be inevitably lost if you have to reload the page, while there are some chances to be saved if the SDK is able to automatically reconnect. What do you think?
* All the logic is placed in the `mainAppController`, would you rather place it in a dedicated controller (will be attached to some high-level DOM node anyway).
* I wrote no functional tests for this feature. Firstly because I don't know how to stop/start the Kuzzle server via Node.js (maybe using the CLI?), secondly because I feel it's a pain to tell Phantom how to detect the notification DOM. Any ideas?