### PR TITLE
Added the setValueViaScript in wdioWrappers

### DIFF
--- a/features/indexes.feature
+++ b/features/indexes.feature
@@ -48,7 +48,6 @@ Feature: Test multi index features
     Then I can see "modal-delete-index" modal
     Then The button "modal-delete-index-delete" is disabled
     Then I fill the input "modal-delete-index-name" with the foo index
-    And I'm waiting 10 sec
     Then The button "modal-delete-index-delete" is not disabled
     And I click on "modal-delete-index-delete" button
     Then I can see "1" indexes in list

--- a/features/step_definitions/indexes/indexes.js
+++ b/features/step_definitions/indexes/indexes.js
@@ -20,8 +20,9 @@ module.exports = function () {
     browser
       .waitForVisible('#' + id, 1000)
       .then(function () {
-        wdioWrappers.setValueViaScript(browser, '#' + id, world.fooIndex, callback);
-      });
+        wdioWrappers.setValueViaScript(browser, '#' + id, world.fooIndex);
+      })
+      .call(callback);
   });
 
   this.When(/^I click on the index selector$/, function (callback) {

--- a/features/step_definitions/indexes/indexes.js
+++ b/features/step_definitions/indexes/indexes.js
@@ -1,6 +1,7 @@
 var
   assert = require('assert'),
-  world = require('../../support/world.js');
+  world = require('../../support/world.js'),
+  wdioWrappers = require('../../support/wdioWrappers');
 
 module.exports = function () {
   this.When(/^I go to manage index page$/, function (callback) {
@@ -18,8 +19,9 @@ module.exports = function () {
   this.When(/^I fill the input "([^"]*)" with the foo index$/, function (id, callback) {
     browser
       .waitForVisible('#' + id, 1000)
-      .setValue('#' + id, world.fooIndex)
-      .call(callback);
+      .then(function () {
+        wdioWrappers.setValueViaScript(browser, '#' + id, world.fooIndex, callback);
+      });
   });
 
   this.When(/^I click on the index selector$/, function (callback) {
@@ -50,7 +52,7 @@ module.exports = function () {
     .click('.indexes-browse .create button')
     .call(callback);
   });
-  
+
   this.When(/^I click on the index option selector of the foo index$/, function (callback) {
     browser
       .waitForVisible('#' + world.fooIndex + ' cog-options-indexes .cog-options-indexes .dropdown-toggle', 1000)

--- a/features/support/wdioWrappers.js
+++ b/features/support/wdioWrappers.js
@@ -51,13 +51,12 @@ module.exports = {
       .call(callback);
   },
 
-  setValueViaScript: function (browser, selector, value, callback) {
+  setValueViaScript: function (browser, selector, value) {
     browser
       .execute(function (selector, value) {
         $(selector).val(value);
         $(selector).trigger('change');
       }, selector, value)
-      .pause(200)
-      .call(callback);
+      .pause(200);
   }
 };

--- a/features/support/wdioWrappers.js
+++ b/features/support/wdioWrappers.js
@@ -49,5 +49,15 @@ module.exports = {
       .waitForEnabled('.modal-dialog .actions-group button', 10000)
       .click('.modal-dialog .actions-group button')
       .call(callback);
+  },
+
+  setValueViaScript: function (browser, selector, value, callback) {
+    browser
+      .execute(function (selector, value) {
+        $(selector).val(value);
+        $(selector).trigger('change');
+      }, selector, value)
+      .pause(200)
+      .call(callback);
   }
 };


### PR DESCRIPTION
We are now able to set input boxes values via Javascript, which is way faster than Webdriver in some (very strange) cases. The JS code is injected by Webdriver into the PhantomJS web browser, which evaluates and executes it in runtime.
This feature is available in `features/support/wdioWrappers.js` as `setValueViaScript`.

This feature is currently used to fill the index deletion modal and is available in case Phantom gets stuck while trying to set input values.
Please, note that this feature is still experimental and is likely to mess things up with AngularJS, which expects DOM events to be triggered on user keystrokes.
Use with care.