### PR TITLE
improved build process to allow it to compile node-sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ phantom.log
 
 # Build assets
 dist
+build.log

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+export BUILDLOG='./build.log'
+
+echo "Building..."
+rimraf dist && webpack --bail --profile --progress -p 2>&1 | tee $BUILDLOG
+
+export FAILURES=$(grep -c "symbol not found" build.log)
+
+if [ $FAILURES -gt 0 ]
+then
+  echo "======= BUILD FAILED. FORCING REINSTALLATION OF FAILED MODULES: "
+
+  for nodemodule in $(grep 'symbol not found' $BUILDLOG | sed -rn 's/^.*node_modules\/(.*)\/.*$/\1/p' | cut -d '/' -f1)
+  do
+    echo "===> REINSTALLING: $nodemodule"
+    npm install --force $nodemodule
+  done
+
+  echo "======= RESTARTING BUILD"
+  npm run build
+fi

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -17,7 +17,7 @@ kuzzle:
     - FEATURE_COVERAGE
 
 kuzzleBo:
-  image: kuzzleio/bo-test
+  image: kuzzleio/bo-test:alpine
   command: /run-dev.sh
   volumes:
     - "..:/var/app"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Official back office for manage and monitor your Kuzzle",
   "main": "app.js",
   "scripts": {
-    "build": "rimraf dist && webpack --bail --profile --progress -p",
+    "build": "./build.sh",
     "test": "rm -f ./features/errorShots/*; ./node_modules/.bin/wdio ./features/wdio.conf.js",
     "test-selective": "rm -f ./features/errorShots/*; ./node_modules/.bin/wdio ./features/wdio.conf.js --cucumberOpts.tags @myTest",
     "start": "./bin/www",


### PR DESCRIPTION
Fixes incompatibilities problem with node-sass: because our new containers are based on alpine linux, node-sass needs to be recompiled to be compatible with musl instead of glibc.
The newest version of these containers now embark the necessary build tools, allowing `npm install` to work from inside these containers.

This pull request fixes a potential problem if `npm install` is performed outside the container, on a glibc-based environement: it provides with a new build chain, detecting incompabilities and forcing a reinstall + recompilation of node modules failing because of that.
