### PR TITLE
Url kuzzle environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ kuzzleBo:
     - "3000:3000"
   links:
     - kuzzle
+  environment:
+    - KUZZLE_URL
 
 redis:
   image: redis:3.0-alpine

--- a/docker-compose/debug.yml
+++ b/docker-compose/debug.yml
@@ -30,6 +30,7 @@ kuzzleBo:
     - kuzzle
   environment:
     - DEVELOPMENT
+    - KUZZLE_URL
 
 redis:
   image: redis:3.0-alpine

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -31,7 +31,8 @@ kuzzleBo:
     # add link to elasticsearch in order to perform a dump
     - elasticsearch
   environment:
-      - DEBUG_PHANTOM
+    - DEBUG_PHANTOM
+    - KUZZLE_URL
 
 redis:
   image: redis:3.0

--- a/docker-compose/test-travis.yml
+++ b/docker-compose/test-travis.yml
@@ -31,7 +31,8 @@ kuzzleBo:
     # add link to elasticsearch in order to perform a dump
     - elasticsearch
   environment:
-      - DEBUG_PHANTOM
+    - DEBUG_PHANTOM
+    - KUZZLE_URL
 
 redis:
   image: redis:3.0-alpine

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -31,7 +31,8 @@ kuzzleBo:
     # add link to elasticsearch in order to perform a dump
     - elasticsearch
   environment:
-      - DEBUG_PHANTOM
+    - DEBUG_PHANTOM
+    - KUZZLE_URL
 
 redis:
   image: redis:3.0-alpine

--- a/src/javascripts/config.js
+++ b/src/javascripts/config.js
@@ -6,7 +6,7 @@
  * @type {{kuzzleUrl: string}}
  */
 var config = {
-  kuzzleUrl: KUZZLE_URL || 'http://localhost:7512',
+  kuzzleUrl: KUZZLE_URL,
   kuzzleCoreIndex: '%kuzzle'
 };
 

--- a/src/javascripts/config.js
+++ b/src/javascripts/config.js
@@ -6,7 +6,7 @@
  * @type {{kuzzleUrl: string}}
  */
 var config = {
-  kuzzleUrl: null,
+  kuzzleUrl: KUZZLE_URL || 'http://localhost:7512',
   kuzzleCoreIndex: '%kuzzle'
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -195,6 +195,7 @@ module.exports = function makeWebpackConfig () {
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
+    new webpack.DefinePlugin({KUZZLE_URL: JSON.stringify(process.env.KUZZLE_URL)})
     /**
      * We'll use the HtmlWebpackPlugin once all the module dependencies are
      * expressed as require() calls.


### PR DESCRIPTION
The user can provide the Kuzzle url on container start for let the browser know where is the Kuzzle

With this `docker-compose.yml`:
```yaml
kuzzleBo:
  image: kuzzleio/bo:alpine
  ports:
    - "3000:3000"
  links:
    - kuzzle
  environment:
    - KUZZLE_URL
```

You can set the Kuzzle url with
`KUZZLE_URL=http://192.10.11.12:7512 docker-compose up`