### PR TITLE
KUZBO-100 : Change doc menu structure and link to the new guide

### DIFF
--- a/src/templates/authentication/logged.template.html
+++ b/src/templates/authentication/logged.template.html
@@ -200,23 +200,9 @@
                   </a>
                   <ul id="menu-help" class="collapse submenu">
                       <li>
-                          <a href="javascript:;" class="collapsed" data-toggle="collapse" data-target="#menu-help-doc">
-                              <!--<i class="fa fa-book"></i>-->
-                              Read the doc
-                              <i class="fa fa-fw fa-caret-down pull-right"></i>
+                          <a href="http://kuzzle.io/guide/" target="_blank">
+                            <i class="fa fa-book"></i> Read the doc
                           </a>
-                          <ul id="menu-help-doc" class="collapse submenu2">
-                              <li>
-                                  <a href="https://github.com/kuzzleio/kuzzle/blob/0.7.2/docs/README.md" target="_blank">
-                                    <i class="fa fa-book"></i> Kuzzle
-                                  </a>
-                              </li>
-                              <li>
-                                  <a href="http://kuzzleio.github.io/sdk-documentation/" target="_blank">
-                                    <i class="fa fa-book"></i> SDK
-                                  </a>
-                              </li>
-                          </ul>
                       </li>
                       <li>
                           <a href="https://gitter.im/kuzzleio/kuzzle" target="_blank">

--- a/src/templates/authentication/logged.template.html
+++ b/src/templates/authentication/logged.template.html
@@ -201,7 +201,7 @@
                   <ul id="menu-help" class="collapse submenu">
                       <li>
                           <a href="http://kuzzle.io/guide/" target="_blank">
-                            <i class="fa fa-book"></i> Read the doc
+                            Read the doc
                           </a>
                       </li>
                       <li>


### PR DESCRIPTION
* Change doc menu structure and link to the new guide
* Remove doc pictogram as it was not pertinent anymore