### PR TITLE
[release-1.0.0-RC3] Docker compose loadbalanced stack

### DIFF
--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -23,12 +23,9 @@ kuzzleBo:
 
 kuzzle:
   image: kuzzleio/kuzzle:develop
-  command: /run-debug.sh
+  command: /run.sh
   volumes:
     - "../features/fixtures.json:/fixtures.json"
-  ports:
-    - "8080:8080"
-    - "8081:8081"
   links:
     - rabbit
     - elasticsearch
@@ -36,7 +33,6 @@ kuzzle:
     - loadbalancer
   environment:
     - MQ_BROKER_ENABLED=1
-    - FEATURE_COVERAGE
     - kuzzle_fixtures=/fixtures.json
 
 rabbit:

--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -23,9 +23,12 @@ kuzzleBo:
 
 kuzzle:
   image: kuzzleio/kuzzle:develop
-  command: /run.sh
+  command: sh -c "npm install -g node-inspector && /run-debug.sh"
   volumes:
     - "../features/fixtures.json:/fixtures.json"
+  ports:
+    - "8080:8080"
+    - "8081:8081"
   links:
     - rabbit
     - elasticsearch


### PR DESCRIPTION
see #58:

> New docker-compose files layout
> 
> * /docker-compose.yml standard Kuzzle stack + Backoffice (static build) without tests nor debug ports.
> * /docker-compose/test.yml standard Kuzzle stack + Backoffice (static build) without debug ports (tests start automatically) [meant for Travis]
> * /docker-compose/dev.yml debug-mode Kuzzle stack + Backoffice (development server) - tests can be run via npm test
> 
