### PR TITLE
[HOTFIX] remove obsolete default import

### DIFF
--- a/src/javascripts/data/storage/browse.controller.js
+++ b/src/javascripts/data/storage/browse.controller.js
@@ -90,5 +90,3 @@ angular.module('kuzzle.storage')
         }, 1000);
       };
     }]);
-
-export default [ctrlName, collectionsDropDownSearch, cogOptionsCollection];

--- a/src/javascripts/security/role/browse.controller.js
+++ b/src/javascripts/security/role/browse.controller.js
@@ -49,4 +49,3 @@ angular.module('kuzzle.role')
     }
   ]);
 
-export default [ctrlName, documentsInline, roleToolbar];


### PR DESCRIPTION
fix a exception thrown by the latest babel-core version 
(see https://github.com/babel/babel/pull/3518 )